### PR TITLE
feat: image resize option

### DIFF
--- a/src/components/PostImage.module.css
+++ b/src/components/PostImage.module.css
@@ -1,7 +1,79 @@
 .img {
   width: 100%;
   object-fit: contain;
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
   vertical-align: middle;
+  /* Blur effect handled by wrapper backgroundImage */
+}
+
+.fullSizeOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.9);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.zoomControls {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #313144;
+  border: 1px solid rgb(140, 141, 255);
+  padding: 8px 12px;
+  z-index: 1001;
+}
+
+.zoomControls > div {
+  padding: 4px 8px;
+  min-width: 32px;
+  min-height: 32px;
+  text-align: center;
+  background: #23232f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zoomControls > div:hover:not([disabled]) {
+  background: rgb(140, 141, 255);
+}
+
+.zoomControls > div[disabled] {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.zoomLevel {
+  color: white;
+  font-size: 1em;
+  min-width: 60px;
+  text-align: center;
+  padding: 0 8px;
+}
+
+.imageContainer {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+}
+
+.fullSizeImg {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  transition: transform 0.2s ease-out;
+  transform-origin: center center;
 }

--- a/src/components/PostImage.tsx
+++ b/src/components/PostImage.tsx
@@ -1,23 +1,137 @@
-import styles from "./PostImage.module.css";
+import { useState, useCallback, useEffect } from "react";
+import PixelarticonsPlus from "~icons/pixelarticons/plus";
+import PixelarticonsMinus from "~icons/pixelarticons/minus";
 
-const maxHeight = "40vh";
-const imgStyle = { maxHeight };
+import styles from "./PostImage.module.css";
+import IconButton from "~/components/IconButton";
+
+const MAX_HEIGHT = "40vh";
+const ZOOM_STEP = 0.25;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 3;
+
+const imgStyle = { maxHeight: MAX_HEIGHT };
 
 interface Props {
   src: string;
-  [key: string]: any;
+  style?: React.CSSProperties;
+  className?: string;
 }
 
-export default function PostImage({ src, ...props }: Props) {
-  const wrapperStyle = {
+export default function PostImage({ src, style, className }: Props) {
+  const [isFullSize, setIsFullSize] = useState(false);
+  const [scale, setScale] = useState(1);
+
+  const openFullSize = useCallback(() => {
+    setIsFullSize(true);
+    setScale(1);
+  }, []);
+
+  const closeFullSize = useCallback(() => {
+    setIsFullSize(false);
+    setScale(1);
+  }, []);
+
+  useEffect(() => {
+    if (!isFullSize) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          closeFullSize();
+          break;
+        case "+":
+        case "=":
+          setScale((prev) => Math.min(prev + ZOOM_STEP, MAX_ZOOM));
+          break;
+        case "-":
+        case "_":
+          setScale((prev) => Math.max(prev - ZOOM_STEP, MIN_ZOOM));
+          break;
+        case "0":
+          setScale(1);
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isFullSize, closeFullSize]);
+
+  useEffect(() => {
+    if (isFullSize) {
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      document.body.style.overflow = "hidden";
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    } else {
+      document.body.style.overflow = "";
+      document.body.style.paddingRight = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+      document.body.style.paddingRight = "";
+    };
+  }, [isFullSize]);
+
+  const zoomIn = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setScale((prev) => Math.min(prev + ZOOM_STEP, MAX_ZOOM));
+  }, []);
+
+  const zoomOut = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setScale((prev) => Math.max(prev - ZOOM_STEP, MIN_ZOOM));
+  }, []);
+
+  const resetZoom = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setScale(1);
+  }, []);
+
+  // Wrapper has blurred background image for letterbox effect
+  const wrapperStyle: React.CSSProperties = {
     backgroundImage: `url('${src}')`,
     backgroundPosition: "center",
-    maxHeight,
+    maxHeight: MAX_HEIGHT,
+    cursor: "pointer",
+    ...style,
   };
-  props.style = { ...wrapperStyle, ...(props.style || {}) };
+
   return (
-    <div {...props}>
-      <img className={styles.img} style={imgStyle} src={src} />
-    </div>
+    <>
+      <div className={className} onClick={openFullSize} style={wrapperStyle}>
+        <img className={styles.img} style={imgStyle} src={src} alt="" />
+      </div>
+
+      {isFullSize && (
+        <div className={styles.fullSizeOverlay} onClick={closeFullSize}>
+          <div className={styles.zoomControls} onClick={(e) => e.stopPropagation()}>
+            <IconButton onClick={zoomOut} disabled={scale <= MIN_ZOOM} title="Zoom out (-)">
+              <PixelarticonsMinus style={{ verticalAlign: "middle" }} />
+            </IconButton>
+            <span 
+              className={styles.zoomLevel} 
+              onClick={resetZoom}
+              title="Click to reset zoom (0)"
+              style={{ cursor: "pointer" }}
+            >
+              {Math.round(scale * 100)}%
+            </span>
+            <IconButton onClick={zoomIn} disabled={scale >= MAX_ZOOM} title="Zoom in (+)">
+              <PixelarticonsPlus style={{ verticalAlign: "middle" }} />
+            </IconButton>
+          </div>
+          <div className={styles.imageContainer}>
+            <img
+              className={styles.fullSizeImg}
+              src={src}
+              alt=""
+              style={{ transform: `scale(${scale})` }}
+              draggable={false}
+            />
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
/claim #3
/fixes #3 

## Description
adds full-size image viewer with zoom controls for post images.

## Changes
- click on any post image to view it in full-screen overlay
- click again to close it
- zoom control

<img width="959" height="437" alt="image" src="https://github.com/user-attachments/assets/934894f0-91a7-4de8-a137-2a2a24064ef5" />

